### PR TITLE
add I2C disabling patches, credit CoolStar

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@
 - 4-21-2018
   - VRAM 1536->2048 ig-platform-id: 0x0a260005
   - VRAM 1536->2048 ig-platform-id: 0x59160000
-
+- 5-2-2018
+  - 添加禁用`Apple` `I2C`补丁，禁止`AppleIntelLpssI2C`连接到i2c控制器
 


### PR DESCRIPTION
- 5-2-2018
  - 添加禁用`Apple` `I2C`补丁，禁止`AppleIntelLpssI2C`连接到i2c控制器